### PR TITLE
Add plugin option: gitCwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog], and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+### Added
+
+- Option to specify a custom working directory for git. ([#29])
+
 ## [1.1.0] - 2019-03-14
 
 Cleaned up original version and fixed the first bug 👌
@@ -35,3 +41,4 @@ create a gulp plugin to stage files 🎉
 [#12]: https://github.com/ericcornelissen/gulp-gitstage/issues/12
 [#14]: https://github.com/ericcornelissen/gulp-gitstage/issues/14
 [#17]: https://github.com/ericcornelissen/gulp-gitstage/issues/17
+[#29]: https://github.com/ericcornelissen/gulp-gitstage/issues/29

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ files.on("data", function(file) {
 
 This plugin takes a single object as configuration. The available options are listed below. Note that all options are optional.
 
-| option | description |
-| ------ | ----------- |
-| `name` | explanation |
+| option   | description                                    |
+| -------- | ---------------------------------------------- |
+| `gitCwd` | Override from which directory git is executed. |
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ files.on("data", function(file) {
 
 ## API
 
-### gitstage()
+### `gitstage(options)`
 
-Currently there is no configuration for `gulp-gitstage`.
+This plugin takes a single object as configuration. The available options are listed below. Note that all options are optional.
+
+| option | description |
+| ------ | ----------- |
+| `name` | explanation |
 
 #### Examples
 

--- a/src/git.js
+++ b/src/git.js
@@ -5,9 +5,11 @@ const which = require("which");
 const git = "git";
 const add = "add";
 
+const defaultOptions = { env: process.env };
 const limiter = new Bottleneck({ maxConcurrent: 1 });
 
-function gitExecute(args, options, callback) {
+function gitExecute(args, _options, callback) {
+  let options = Object.assign(defaultOptions, _options);
   return limiter.submit(exec, git, args, options, callback);
 }
 
@@ -27,8 +29,8 @@ Object.defineProperty(_export, "available", {
   },
 });
 
-_export.stage = function(file, options, callback) {
-  return gitExecute([add, file], options, callback);
+_export.stage = function(file, config, callback) {
+  return gitExecute([add, file], config, callback);
 };
 
 module.exports = _export;

--- a/src/git.js
+++ b/src/git.js
@@ -8,6 +8,21 @@ const add = "add";
 const defaultOptions = { env: process.env };
 const limiter = new Bottleneck({ maxConcurrent: 1 });
 
+/**
+ * Execute arbitrary git commands one at the time. When
+ * multiple calls are performed in quick succession the
+ * git commands are automatically rate limited.
+ *
+ * Example:
+ * ```
+ * gitExecute(['add', 'myfile.txt'], options, callback);
+ * // -> executes: $ git add myfile.txt
+ * ```
+ *
+ * @param  {Array}    args     The arguments for the command in order.
+ * @param  {Object}   _options Options for the command.
+ * @param  {Function} callback Function called on completion.
+ */
 function gitExecute(args, _options, callback) {
   let options = Object.assign(defaultOptions, _options);
   return limiter.submit(exec, git, args, options, callback);

--- a/src/git.js
+++ b/src/git.js
@@ -48,6 +48,12 @@ Object.defineProperty(_export, "available", {
   },
 });
 
+/**
+ * @param  {String}   file     The path to the file to stage.
+ * @param  {Object}   config   Configuration of the stage action.
+ *                      - gitCwd: directory containing the '.git' folder.
+ * @param  {Function} callback The function to call on completion.
+ */
 _export.stage = function(file, config, callback) {
   return gitExecute([add, file], config, callback);
 };

--- a/src/git.js
+++ b/src/git.js
@@ -21,10 +21,14 @@ const limiter = new Bottleneck({ maxConcurrent: 1 });
  *
  * @param  {Array}    args     The arguments for the command in order.
  * @param  {Object}   _options Options for the command.
+ *                      - gitCwd: directory containing the '.git' folder.
  * @param  {Function} callback Function called on completion.
  */
 function gitExecute(args, _options, callback) {
-  let options = Object.assign(defaultOptions, _options);
+  let options = Object.assign(defaultOptions, {
+    cwd: _options.gitCwd || __dirname,
+  });
+
   return limiter.submit(exec, git, args, options, callback);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ module.exports = function(config = {}) {
       return callback(new Error("git not found on your system."));
     }
 
+    if (config.gitCwd !== undefined && typeof config.gitCwd !== "string") {
+      return callback(new Error("the 'gitCwd' option must be a string."));
+    }
+
     git.stage(file.path, config, error => {
       if (error) {
         return callback(new Error("git add failed."));

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,13 @@
 const map = require("map-stream");
 const git = require("./git");
 
-const defaultOptions = { env: process.env };
-
-module.exports = function() {
+module.exports = function(config = {}) {
   return map(function(file, callback) {
     if (!git.available) {
       return callback(new Error("git not found on your system."));
     }
 
-    git.stage(file.path, defaultOptions, error => {
+    git.stage(file.path, config, error => {
       if (error) {
         return callback(new Error("git add failed."));
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,3 +69,37 @@ describe("successful execution", () => {
       );
   });
 });
+
+describe("Configuration", () => {
+  test("the 'gitCwd' option is used", done => {
+    let customCwd = "../foo";
+    gulp
+      .src(files)
+      .pipe(
+        gitstage({
+          gitCwd: customCwd,
+        }),
+      )
+      .pipe(reduce())
+      .pipe(
+        each(() => {
+          expect(process.execFile).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.objectContaining({
+              cwd: customCwd,
+            }),
+            expect.anything(),
+          );
+
+          done();
+        }),
+      );
+  });
+
+  test("the 'gitCwd' option must be a string", () => {
+    const subject = gitstage({ gitCwd: ["not", "a", "string"] });
+    expect(subject).toHaveProperty("write");
+    expect(subject.write).toThrow();
+  });
+});


### PR DESCRIPTION
Add an option to specify the working directory of the git repository (i.e. the directory containing the `.git` folder), similar to [the option with the same name in gulp-gitmodified](https://github.com/mikaelbr/gulp-gitmodified#options).

Closes #6