### PR TITLE
Stage files based on relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 ### Changed
 
 - Abstract dependencies behind local modules. ([#42])
+- Commit files based on relative rather than absolute path. ([#47])
 
 ## [1.3.0] - 2019-03-19
 
@@ -72,3 +73,4 @@ create a gulp plugin to stage files :tada:
 [#38]: https://github.com/ericcornelissen/gulp-gitstage/pull/38
 [#41]: https://github.com/ericcornelissen/gulp-gitstage/pull/41
 [#42]: https://github.com/ericcornelissen/gulp-gitstage/pull/42
+[#47]: https://github.com/ericcornelissen/gulp-gitstage/pull/47

--- a/src/git.js
+++ b/src/git.js
@@ -31,7 +31,7 @@ function gitExecute(args, _options, callback) {
   }
 
   const options = Object.assign(DEFAULT_OPTIONS, {
-    cwd: _options.gitCwd || __dirname,
+    cwd: _options.gitCwd,
   });
 
   return limiter.schedule(exec, git, args, options, callback);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const map = require("map-stream");
+const path = require("path");
 const PluginError = require("plugin-error");
 
 const git = require("./git.js");
@@ -7,13 +8,16 @@ const { errorTag, types } = require("./constants.js");
 module.exports = function(config = {}) {
   const streamId = Math.random();
 
-  return map((file, callback) => {
+  return map((_file, callback) => {
+    const gitRoot = path.resolve(_file.cwd, config.gitCwd || "");
+    const file = path.relative(gitRoot, _file.path);
+
     if (config.gitCwd && typeof config.gitCwd !== types.string) {
       const error = new PluginError(errorTag, "'gitCwd' must be a string.");
       return callback(error);
     }
 
-    git.stage(file.path, config, streamId, error => {
+    git.stage(file, config, streamId, error => {
       if (error) {
         const errorMessage = error.message.split(/\n/)[1];
         const [code, message] = errorMessage.split(/:\s/);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,7 +55,7 @@ describe("successful execution", () => {
 
     gulp
       .src(files)
-      .pipe(each(file => fileList.push(file.path)))
+      .pipe(each(file => fileList.push(file.basename)))
       .pipe(gitstage())
       .pipe(reduce())
       .pipe(
@@ -63,7 +63,7 @@ describe("successful execution", () => {
           for (let file of fileList) {
             expect(process.execFile).toHaveBeenCalledWith(
               expect.anything(),
-              expect.arrayContaining([file]),
+              expect.arrayContaining([expect.stringContaining(file)]),
               expect.anything(),
               expect.anything(),
             );


### PR DESCRIPTION
### Checklist

<!-- Check if you did all these things, or explain why you did not -->

- [x] I tested the change(s) in this Pull Request
- [ ] I documented the change(s) in this Pull Request
- [x] I added the change(s) to the [changelog](https://github.com/ericcornelissen/gulp-gitstage/blob/master/CHANGELOG.md)

### Issues

n/a

### Description

Change the file path given to git from the absolute path of the file (obtained [from Vinyl](https://gulpjs.com/docs/en/api/vinyl)) to a path relative based on the cwd of gulp and the `gitCwd` option.