### PR TITLE
Git module export

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -98,23 +98,27 @@ function isGitAvailable() {
 }
 
 /**
- * Provides an API to interact with git.
+ * Provides a class with an API to interact with git.
  * @module git
+ * @example
+ * const Git = require('path/to/git.js');
+ * const git = new Git();
  */
-module.exports = {
+module.exports = function() {
+  const id = Math.random();
+
   /**
    * Stage a file in a git repository.
    *
    * @param  {String} file - Path to the file to stage.
    * @param  {String} gitCwd - Relative path to the root of the git repository.
    * @param  {Boolean} stagedOnly - Only stage previously staged files.
-   * @param  {Any} streamId - An identifier to bundle multiple files.
    * @param  {Function} callback - The function to call on completion.
    * @throws {TypeError} Callback is not a function.
    * @throws {Error} The git command is not present.
    * @example
    * const config = {gitCwd: "../", stagedOnly: false};
-   * stage('my-file.js', config, 42, error => {
+   * stage('my-file.js', config, error => {
    *  if (error) {
    *    console.log('Failed.');
    *  } else {
@@ -122,14 +126,14 @@ module.exports = {
    *  }
    * });
    */
-  stage: function(file, config, streamId, callback) {
+  this.stage = function(file, config, callback) {
     if (typeof file !== types.string) {
       callback("file must be a string.");
     } else if (typeof callback !== types.function) {
       throw new TypeError("callback is not a function");
     } else {
-      const stageBuffer = getStageBufferForStream(streamId);
+      const stageBuffer = getStageBufferForStream(id);
       stageBuffer.push(file, config, callback);
     }
-  },
+  };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const path = require("path");
 const PluginError = require("plugin-error");
 
 const { errorTag, types } = require("./constants.js");
-const git = require("./git.js");
+const Git = require("./git.js");
 
 /**
  * Exposes the plugin 'gitstage' to be used in {@link https://gulpjs.com/ Gulp}.
@@ -17,7 +17,7 @@ const git = require("./git.js");
  * @return {Stream}                     Identity file stream, does not modify the input.
  */
 module.exports = function(config = {}) {
-  const streamId = Math.random();
+  const git = new Git();
 
   return map((_file, callback) => {
     const gitRoot = path.resolve(_file.cwd, config.gitCwd || "");
@@ -28,7 +28,7 @@ module.exports = function(config = {}) {
       return callback(error);
     }
 
-    git.stage(file, config, streamId, error => {
+    git.stage(file, config, error => {
       if (error) {
         const errorMessage = error.message.split(/\n/)[1];
         const [code, message] = errorMessage.split(/:\s/);

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -4,9 +4,14 @@ const path = require("path");
 const { stdin, stdout } = require("./utils.js");
 
 const command = require("../src/constants.js");
-const git = require("../src/git.js");
+const Git = require("../src/git.js");
 
 const file = path.join(__dirname, "./fixtures/a.txt");
+
+let git;
+beforeEach(() => {
+  git = new Git();
+});
 
 test("can be used to execute the 'git add' command", () => {
   expect(git).toHaveProperty("stage");
@@ -15,14 +20,14 @@ test("can be used to execute the 'git add' command", () => {
 
 describe("successful execution", () => {
   test("calls execFile", done => {
-    git.stage(file, {}, 0.0, () => {
+    git.stage(file, {}, () => {
       expect(process.execFile).toHaveBeenCalled();
       done();
     });
   });
 
   test("attempts to execute git", done => {
-    git.stage(file, {}, 0.314, () => {
+    git.stage(file, {}, () => {
       expect(process.execFile).toHaveBeenCalledWith(
         command.git,
         expect.anything(),
@@ -35,7 +40,7 @@ describe("successful execution", () => {
   });
 
   test("attempts to add the file", done => {
-    git.stage(file, {}, 0.7, () => {
+    git.stage(file, {}, () => {
       expect(process.execFile).toHaveBeenCalledWith(
         expect.anything(),
         [command.add, file],
@@ -48,7 +53,7 @@ describe("successful execution", () => {
   });
 
   test("provides an object as options", done => {
-    git.stage(file, {}, 0.42, () => {
+    git.stage(file, {}, () => {
       expect(process.execFile).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -61,7 +66,7 @@ describe("successful execution", () => {
   });
 
   test("attempts to execute git", done => {
-    git.stage(file, {}, 0.22, () => {
+    git.stage(file, {}, () => {
       expect(process.execFile).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -74,39 +79,39 @@ describe("successful execution", () => {
   });
 
   test("the first parameter of the callback", done => {
-    git.stage(file, {}, 0.161803, a => {
+    git.stage(file, {}, a => {
       expect(a).toBeNull();
       done();
     });
   });
 
   test("the second parameter of the callback", done => {
-    git.stage(file, {}, 0.9001, (a, b) => {
+    git.stage(file, {}, (a, b) => {
       expect(b).toBe(stdin);
       done();
     });
   });
 
   test("the third parameter of the callback", done => {
-    git.stage(file, {}, 0.167, (a, b, c) => {
+    git.stage(file, {}, (a, b, c) => {
       expect(c).toBe(stdout);
       done();
     });
   });
 
   test("gives an error if file is not a string", done => {
-    git.stage(() => true, {}, 0.2718, error => {
+    git.stage(() => true, {}, error => {
       expect(error).not.toBeNull();
       done();
     });
   });
 
   test("throws an error if callback is not a function", () => {
-    expect(() => git.stage("", {}, 42, false)).toThrowError(TypeError);
+    expect(() => git.stage("", {}, false)).toThrowError(TypeError);
   });
 
   test("does not attempt to execute git if file is not a string", done => {
-    git.stage(() => true, {}, 0.1337, error => {
+    git.stage(() => true, {}, error => {
       expect(process.execFile).not.toHaveBeenCalled();
       done();
     });
@@ -125,7 +130,7 @@ describe("unsuccessful execution", () => {
   });
 
   test("the first parameter of the callback", done => {
-    git.stage(file, {}, 0.80085, error => {
+    git.stage(file, {}, error => {
       expect(error).not.toBeNull();
       done();
     });

--- a/test/nogit.test.js
+++ b/test/nogit.test.js
@@ -1,5 +1,5 @@
 const gitstage = require("../src/index.js");
-const git = require("../src/git.js");
+const Git = require("../src/git.js");
 
 beforeAll(() => {
   // Clear the PATH so git definitely cannot be found
@@ -13,5 +13,6 @@ test("the plugin throws", () => {
 });
 
 test("the 'stage' function throws if git is not available", () => {
+  const git = new Git();
   expect(git.stage).toThrow();
 });


### PR DESCRIPTION
### Checklist

<!-- Check if you did all these things, or explain why you did not -->

- [x] I tested the change(s) in this Pull Request
- [x] I documented the change(s) in this Pull Request
- _(n/a)_ I added the change(s) to the [changelog](https://github.com/ericcornelissen/gulp-gitstage/blob/master/CHANGELOG.md)

### Issues

Closes #50

### Description

Prevent the user of the `git.js` module from having to specify a (unique) identifier for it's calls, potentially doing something wrong. By refactoring the module into exporting a class that generates its own identifier this software development issue has been resolved 👌 
