### PR TITLE
Hide debounce dependency into its own module

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -46,6 +46,7 @@ module.exports = {
    */
   types: {
     function: "function",
+    number: "number",
     string: "string",
   },
 };

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,3 +1,5 @@
+const { types } = require("./constants.js");
+
 /**
  * Provides a function to debounce calls to a specific function.
  * @module debounce
@@ -12,5 +14,12 @@
  */
 module.exports = function(fn, timeout) {
   const debounce = require("debounce");
-  return debounce(fn, timeout, false);
+
+  if (typeof fn !== types.function) {
+    throw new TypeError("fn is not a function");
+  } else if (typeof timeout !== types.number) {
+    throw new TypeError("timeout is not a number");
+  } else {
+    return debounce(fn, timeout, false);
+  }
 };

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -4,10 +4,10 @@ const { types } = require("./constants.js");
  * Provides a function to debounce calls to a specific function.
  * @module debounce
  * @param  {Function} fn - the function to debounce.
- * @param  {Number} timeout - the time to wait before executing {@link fn}.
+ * @param  {Number} timeout - the time (in milliseconds) to wait before executing {@link fn}.
  * @return {Function} The debounced function.
  * @example
- * const debouncedLog = debounce(console.log);
+ * const debouncedLog = debounce(console.log, 100);
  * debouncedLog("foo");
  * debouncedLog("bar");
  * // -> "bar"

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,16 @@
+/**
+ * Provides a function to debounce calls to a specific function.
+ * @module debounce
+ * @param  {Function} fn - the function to debounce.
+ * @param  {Number} timeout - the time to wait before executing {@link fn}.
+ * @return {Function} The debounced function.
+ * @example
+ * const debouncedLog = debounce(console.log);
+ * debouncedLog("foo");
+ * debouncedLog("bar");
+ * // -> "bar"
+ */
+module.exports = function(fn, timeout) {
+  const debounce = require("debounce");
+  return debounce(fn, timeout, false);
+};

--- a/src/git.js
+++ b/src/git.js
@@ -1,5 +1,6 @@
 const callLimiter = require("./call-limiter.js");
 const { add, git, types, update } = require("./constants.js");
+const debounce = require("./debounce.js");
 const log = require("./log.js");
 
 const BUFFER_DELAY = 150;
@@ -52,8 +53,6 @@ function gitExecute(args, _options, callback) {
  * stageBuffer.push(file, options, callback)
  */
 function getStageBufferForStream(id) {
-  const debounce = require("debounce");
-
   if (STAGE_BUFFERS[id] === undefined) {
     const callbacks = [];
     const files = [];

--- a/test/debounce.test.js
+++ b/test/debounce.test.js
@@ -1,0 +1,75 @@
+const debounce = require("../src/debounce.js");
+
+test("Does not throw an error", () => {
+  expect(() => debounce(jest.fn(), 1)).not.toThrow();
+});
+
+test("Requires a function to call", () => {
+  expect(() => debounce()).toThrow();
+  expect(() => debounce("not a function")).toThrow();
+});
+
+test("Requires a timeout value", () => {
+  let fn = jest.fn();
+  expect(() => debounce(fn)).toThrow();
+  expect(() => debounce(fn, "not a number")).toThrow();
+});
+
+describe("Debouncing", () => {
+  const timeout = 50;
+
+  let fn, debouncedFn;
+  beforeEach(() => {
+    // Prepare a spied function and debounced version of that function to be
+    // used in the test suite.
+    fn = jest.fn();
+    debouncedFn = debounce(fn, timeout);
+  });
+
+  test("Executes the function only once", () => {
+    debouncedFn();
+    debouncedFn();
+
+    setTimeout(() => {
+      expect(fn).toHaveBeenCalledTimes(1);
+    }, timeout);
+  });
+
+  test("Executes the last call to the function", () => {
+    const message = "Hello world!";
+
+    debouncedFn("foo");
+    debouncedFn("bar");
+    debouncedFn(message);
+
+    setTimeout(() => {
+      expect(fn).toHaveBeenCalledWith(message);
+    }, timeout);
+  });
+
+  test("Executes the function again after the specified timeout", () => {
+    const message = "Hello world!";
+
+    debouncedFn();
+    setTimeout(debouncedFn, timeout * 2);
+
+    setTimeout(() => {
+      expect(fn).toHaveBeenCalledTimes(2);
+    }, timeout * 3);
+  });
+
+  test("Executes the function only once after the specified timeout", () => {
+    const message = "Hello world!";
+
+    debouncedFn();
+    debouncedFn();
+    setTimeout(() => {
+      debouncedFn();
+      debouncedFn();
+    }, timeout * 2);
+
+    setTimeout(() => {
+      expect(fn).toHaveBeenCalledTimes(2);
+    }, timeout * 3);
+  });
+});


### PR DESCRIPTION
### Checklist

<!-- Check if you did all these things, or explain why you did not -->

- [x] I tested the change(s) in this Pull Request
- [x] I documented the change(s) in this Pull Request
- _(n/a)_ I added the change(s) to the [changelog](https://github.com/ericcornelissen/gulp-gitstage/blob/master/CHANGELOG.md)

### Issues

Closes #43

### Description

Refactored the codebase such that the [debounce](https://www.npmjs.com/package/debounce) dependency is now hidden behind a local module.

Following the software engineering principle to do exactly that, hide dependencies behind local modules with the aim of having to change only a single file when the dependencies API changes.