### PR TITLE
Remove Greenkeeper badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build status][travisci-image]][travisci-url]
 [![Coverage][codecov-image]][codecov-url]
 [![Dependencies][daviddm-image]][daviddm-url]
-[![Greenkeeper][greenkeeper-image]][greenkeeper-url]
 [![License][license-image]][license-url]
 [![Prettier][prettier-image]][prettier-url]
 
@@ -95,8 +94,6 @@ Read more in the <a href="\CONTRIBUTING.md">Contributing Guidelines</a> and <a h
 [codecov-image]: https://codecov.io/gh/ericcornelissen/gulp-gitstage/branch/master/graph/badge.svg
 [daviddm-url]: https://david-dm.org/ericcornelissen/gulp-gitstage
 [daviddm-image]: https://david-dm.org/ericcornelissen/gulp-gitstage/status.svg
-[greenkeeper-url]: https://greenkeeper.io/
-[greenkeeper-image]: https://badges.greenkeeper.io/ericcornelissen/gulp-gitstage.svg
 [license-url]: https://opensource.org/licenses/MIT
 [license-image]: https://img.shields.io/badge/License-MIT-yellow.svg
 [prettier-url]: https://prettier.io/


### PR DESCRIPTION
This Pull Request removes the Greenkeeper badge from the `README.md` (Greenkeeper has been removed from the project).