### PR TITLE
Fix the stagedOnly option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+## [Unreleased]
+
+### Fixed
+
+- Make the `stagedOnly` flag work as intended. ([#87])
+
 ## [1.4.3] - 2020-04-10
 
 ### Security
@@ -105,3 +111,4 @@ create a gulp plugin to stage files :tada:
 [#75]: https://github.com/ericcornelissen/gulp-gitstage/pull/75
 [#83]: https://github.com/ericcornelissen/gulp-gitstage/pull/83
 [#84]: https://github.com/ericcornelissen/gulp-gitstage/pull/84
+[#87]: https://github.com/ericcornelissen/gulp-gitstage/pull/87

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -19,18 +19,19 @@ module.exports = {
 
   /**
    * String denoting the 'add' verb for 'git'. See {@link
-   * https://git-scm.com/docs/git-add the docs}.
+   * https://git-scm.com/docs/git-update-index the docs}. Instead of using the
+   * standard `git add` we use instead `git update-index`, as it is more
+   * powerful.
    * @constant {String}
    */
-  add: "add",
+  add: "update-index",
 
   /**
    * String denoting the 'update' option for the 'add' verb for 'git'. See
-   * {@link https://git-scm.com/docs/git-add#Documentation/git-add.txt--u
-   * the docs}.
+   * {@link https://git-scm.com/docs/git-update-index the docs}.
    * @constant {String}
    */
-  update: "-u",
+  update: "-g",
 
   /* === type names === */
 


### PR DESCRIPTION

### Checklist

<!-- Check if you did all these things, or explain why you did not -->

- [x] I tested the change(s) in this Pull Request
- ~~I documented the change(s) in this Pull Request~~
- [x] I added the change(s) to the [changelog](https://github.com/ericcornelissen/gulp-gitstage/blob/master/CHANGELOG.md)

### Issues

None

### Description

Fix the `stagedOnly` option by switching from ['git add'](https://git-scm.com/docs/git-add) to ['git update-index'](https://git-scm.com/docs/git-update-index). The `-u` flag for 'git add' does not in fact only update the index of staged files, but will also stage previously not-staged files. In fact, 'git add' does not have an option to do this. This is why the code now uses 'git update-index', which you can consider as a more powerful version of 'git add'. Evidenced, for a start, by the fact that it allows you to update the index only if the file was previously staged
